### PR TITLE
Upgrade dnspython dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = {text = "MIT License"}
 requires-python = ">=3.9"
 dependencies = [
-    "dnspython==2.4.2"
+    "dnspython<2.7"
 ]
 keywords = ["spf", "sender policy framework", "email"]
 


### PR DESCRIPTION
Hello Frank

We use `dnspython` and `spf-validator` in our DNS management. There is a vulnerability in the `dnspython<2.6.1`, see https://nvd.nist.gov/vuln/detail/CVE-2023-29483. So I tried to upgrade it. However, `spf-validator` depends on `dnspython==2.4.2`. There is a patch which increases version of the `dnspython`.

Jan Seifert
