### PR TITLE
Add Validation for too-many includes

### DIFF
--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -176,7 +176,7 @@ def get_domain_spf_record(domain: str) -> str:
 
     try:
         txt_records = dns.resolver.resolve(domain, "TXT")
-    except dns.resolver.NoAnswer:
+    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
         return ""
 
     # Loop through the records and find the SPF record.

--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -130,6 +130,30 @@ def validate_spf_string(spf: str) -> list[str]:
             "The SPF record contains the 'ptr' mechanism which is not longer in the SPF specification and can result in a larger number of expensive DNS lookups."
         )
 
+    ###
+    # Recursive includes
+    ###
+    max_dns_queries = 10
+    include_regex = re.compile(r"\binclude:\S+\b")
+
+    def _get_includes_recursive(_spf: str) -> list:
+        inc = []
+
+        for i in include_regex.findall(_spf):
+            d = i.split(':', 1)[1]
+            inc.append(d)
+            inc.extend(_get_includes_recursive(
+                get_domain_spf_record(d)
+            ))
+
+        return inc
+
+    includes = _get_includes_recursive(spf)
+    if len(includes) > max_dns_queries:
+        issues.append(
+            f"Include count exceeded - {len(includes)}/{max_dns_queries} ({', '.join(includes)})"
+        )
+
     return issues
 
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -88,4 +88,4 @@ def test_valid_spf_string():
 
 def test_too_many_includes():
     includes = [f'include:{letter}.example.com' for letter in 'abcdefghijklmn']
-    assert len(validator.validate_spf_string(f"v=spf1 {' '.join(includes)} -all")) > 1
+    assert len(validator.validate_spf_string(f"v=spf1 {' '.join(includes)} -all")) == 2

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -84,3 +84,8 @@ def test_ptr_mechanism():
 def test_valid_spf_string():
     """Test a valid SPF string."""
     assert len(validator.validate_spf_string("v=spf1 include:example.com -all")) == 0
+
+
+def test_too_many_includes():
+    includes = [f'include:{letter}.example.com' for letter in 'abcdefghijklmn']
+    assert len(validator.validate_spf_string(f"v=spf1 {' '.join(includes)} -all")) > 1


### PR DESCRIPTION
Validate for too many includes (max 10) as this happens in practice some times.
See RFC: https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4