### PR TITLE
Fix for catchall matching

### DIFF
--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -77,7 +77,7 @@ def validate_spf_string(spf: str) -> list[str]:
     # Catchall checks
     ###
 
-    catchall_regex = re.compile(r"\s[~\+\-\?]all\b")
+    catchall_regex = re.compile(r"\s[~\+\-\?]?all\b")
     catchall_instances = catchall_regex.findall(spf)
     print(catchall_instances)
 

--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -77,8 +77,9 @@ def validate_spf_string(spf: str) -> list[str]:
     # Catchall checks
     ###
 
-    catchall_regex = re.compile(r"\S?all\b")
+    catchall_regex = re.compile(r"\s[~\+\-\?]all\b")
     catchall_instances = catchall_regex.findall(spf)
+    print(catchall_instances)
 
     if len(catchall_instances) == 0:
         issues.append(
@@ -93,7 +94,8 @@ def validate_spf_string(spf: str) -> list[str]:
         if catchall_instance.span()[1] != len(spf):
             issues.append("The catchall is not at the end of the SPF record.")
 
-        if catchall_instance.group()[0] == "+" or catchall_instance.group()[0] == "a":
+        catchall = catchall_instance.group().strip()
+        if catchall[0] in ["+", "a"]:
             issues.append(
                 "The catchall is prefixed with + qualifier. This means that the SPF record will always pass which allows anyone to send emails claiming to be from you. This is not recommended."
             )

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -57,7 +57,7 @@ def test_catchall_not_at_end():
 
 def test_permissive_catchall():
     """Test an SPF string with a permissive catchall."""
-    assert len(validator.validate_spf_string("v=spf1 +all")) > 0
+    assert len(validator.validate_spf_string("v=spf1 +all")) == 1
 
 
 def test_invalid_ip4():

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -84,3 +84,7 @@ def test_ptr_mechanism():
 def test_valid_spf_string():
     """Test a valid SPF string."""
     assert len(validator.validate_spf_string("v=spf1 include:example.com -all")) == 0
+
+
+def test_catchall_false_positive():
+    assert len(validator.validate_spf_string("v=spf1 include:all.example.com -all")) == 0


### PR DESCRIPTION
The current catchall regex also matches any `all` string inside the spf record.

Example:
`v=spf1 include:all.example.com -all => ['all', '-all']`

This PR fixes the behavior