### PR TITLE
Update tests and requirements to work with Python 3.14 and dnspython 2.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         dnspython-version: [ '2.5.0', '2.6.1', '2.7.0']
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dnspython-version: [ '2.5.0', '2.6.1', '2.7.0']
+        dnspython-version: [ '2.5.0', '2.6.1', '2.7.0', '2.8.0']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = {text = "MIT License"}
 requires-python = ">=3.9"
 dependencies = [
-    "dnspython>=2.5,<2.8"
+    "dnspython>=2.5,<2.9"
 ]
 keywords = ["spf", "sender policy framework", "email"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spf_validator"
-version = "1.3.1"
+version = "1.4.0"
 authors = [
   { name="Frank Corso", email="frank@frankcorso.me" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Validates Sender Policy Framework (SPF) strings to ensure they are formatted correctly."
 readme = "README.md"
 license = {text = "MIT License"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "dnspython>=2.5,<2.9"
 ]

--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -189,7 +189,34 @@ def get_domain_spf_record(domain: str) -> str:
     Returns:
         The SPF record for the domain.
     """
-    # If the domain is a URL, remove protocol, paths, and ports from it.
+    domain = _normalize_domain(domain)
+    if not domain:
+        return ""
+
+    # Loop through the TXT records and find the SPF record.
+    txt_records = _get_txt_records_from_domain(domain)
+    for record in txt_records:
+        if "v=spf" in record:
+            return record
+
+    # If we get here, we didn't find an SPF record.
+    return ""
+
+
+def _normalize_domain(domain: str) -> str:
+    """
+    Normalize a given domain name by stripping protocol and common subdomain.
+
+    Args:
+        domain: The domain name or URL to be normalized.
+
+    Returns:
+        The normalized domain name as a string. Returns an empty string if the input
+        domain is empty.
+    """
+    if not domain:
+        return ""
+
     if "://" in domain:
         domain = urlparse(domain).hostname
 
@@ -197,17 +224,21 @@ def get_domain_spf_record(domain: str) -> str:
     if domain.startswith("www."):
         domain = domain[4:]
 
+    return domain
+
+def _get_txt_records_from_domain(domain: str) -> list:
+    """
+    Get the TXT records for a domain.
+
+    Args:
+        domain: The domain name.
+
+    Returns:
+        A list of TXT records for the domain.
+    """
     try:
         txt_records = dns.resolver.resolve(domain, "TXT")
+        return ["".join([a.decode("utf-8") for a in record.strings])
+                for record in txt_records]
     except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
-        return ""
-
-    # Loop through the records and find the SPF record.
-    for record in txt_records:
-        # Convert the record to a string.
-        record_text = "".join([a.decode("utf-8") for a in record.strings])
-        if "v=spf" in record_text:
-            return record_text
-
-    # If we get here, we didn't find an SPF record.
-    return ""
+        return []

--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -226,8 +226,8 @@ def _normalize_domain(domain: str) -> str:
     if not domain:
         return ""
 
-    # Remove protocol, ports, query args, etc...
-    domain = urlparse(domain).hostname or ""
+    if "://" in domain:
+        domain = urlparse(domain).hostname or ""
 
     # Remove www subdomain (if present)
     if domain.startswith("www."):

--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -15,7 +15,7 @@ def validate_domain_spf(domain: str) -> list[str]:
         A list of issues with the SPF record. If the list is empty, the SPF record is valid.
     """
     if not domain:
-        return ['Invalid domain name provided for SPF validation.']
+        return ["Invalid domain name provided for SPF validation."]
 
     issues = []
 
@@ -131,11 +131,9 @@ def validate_spf_string(spf: str) -> list[str]:
         inc = []
 
         for i in include_regex.findall(_spf):
-            d = i.split(':', 1)[1]
+            d = i.split(":", 1)[1]
             inc.append(d)
-            inc.extend(_get_includes_recursive(
-                get_domain_spf_record(d)
-            ))
+            inc.extend(_get_includes_recursive(get_domain_spf_record(d)))
 
         return inc
 
@@ -148,20 +146,31 @@ def validate_spf_string(spf: str) -> list[str]:
     ###
     # Check for unknown parts
     ###
-    valid_parts_full = ['a', 'mx', 'ptr']
+    valid_parts_full = ["a", "mx", "ptr"]
     valid_parts_beg = [
-        'v=spf',
-        'a:', 'mx:', 'ip4:', 'ip6:',
-        'exists:', 'include:', 'redirect:', 'exp:',
-        'all',
+        "v=spf",
+        "a:",
+        "mx:",
+        "ip4:",
+        "ip6:",
+        "exists:",
+        "include:",
+        "redirect:",
+        "exp:",
+        "all",
     ]
 
-    for part in spf.split(' '):
-        if part == '':
+    for part in spf.split(" "):
+        if part == "":
             continue
 
         part = part.lower().strip()
-        if part.startswith('-') or part.startswith('+') or part.startswith('~') or part.startswith('?'):
+        if (
+            part.startswith("-")
+            or part.startswith("+")
+            or part.startswith("~")
+            or part.startswith("?")
+        ):
             part = part[1:]
 
         any_valid = False
@@ -226,6 +235,7 @@ def _normalize_domain(domain: str) -> str:
 
     return domain
 
+
 def _get_txt_records_from_domain(domain: str) -> list:
     """
     Get the TXT records for a domain.
@@ -238,7 +248,9 @@ def _get_txt_records_from_domain(domain: str) -> list:
     """
     try:
         txt_records = dns.resolver.resolve(domain, "TXT")
-        return ["".join([a.decode("utf-8") for a in record.strings])
-                for record in txt_records]
+        return [
+            "".join([a.decode("utf-8") for a in record.strings])
+            for record in txt_records
+        ]
     except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
         return []

--- a/src/spf_validator/validator.py
+++ b/src/spf_validator/validator.py
@@ -226,8 +226,8 @@ def _normalize_domain(domain: str) -> str:
     if not domain:
         return ""
 
-    if "://" in domain:
-        domain = urlparse(domain).hostname
+    # Remove protocol, ports, query args, etc...
+    domain = urlparse(domain).hostname or ""
 
     # Remove www subdomain (if present)
     if domain.startswith("www."):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -107,7 +107,3 @@ def test_normalize_domain_protocol():
 def test_normalize_domain_strips_www_only():
     assert validator._normalize_domain("www.example.com") == "example.com"
     assert validator._normalize_domain("example.com") == "example.com"
-
-
-def test_normalize_domain_non_domain():
-    assert validator._normalize_domain("not a domain") == ""

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -92,6 +92,10 @@ def test_catchall_false_positive():
     )
 
 
+def test_normalize_domain_valid():
+    assert validator._normalize_domain("example.com") == "example.com"
+
+
 def test_normalize_domain_empty():
     assert validator._normalize_domain("") == ""
 
@@ -100,6 +104,14 @@ def test_normalize_domain_protocol():
     assert validator._normalize_domain("https://example.com") == "example.com"
 
 
+def test_normalize_domain_port():
+    assert validator._normalize_domain("example.com:80") == "example.com"
+
+
 def test_normalize_domain_strips_www_only():
     assert validator._normalize_domain("www.example.com") == "example.com"
     assert validator._normalize_domain("example.com") == "example.com"
+
+
+def test_normalize_domain_non_domain():
+    assert validator._normalize_domain("not a domain") == ""

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -104,10 +104,6 @@ def test_normalize_domain_protocol():
     assert validator._normalize_domain("https://example.com") == "example.com"
 
 
-def test_normalize_domain_port():
-    assert validator._normalize_domain("example.com:80") == "example.com"
-
-
 def test_normalize_domain_strips_www_only():
     assert validator._normalize_domain("www.example.com") == "example.com"
     assert validator._normalize_domain("example.com") == "example.com"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -73,18 +73,23 @@ def test_valid_spf_string():
     """Test a valid SPF string."""
     assert len(validator.validate_spf_string("v=spf1 include:example.com -all")) == 0
 
-    
+
 def test_unknown_parts():
-    assert len(validator.validate_spf_string("v=spf1 random include:example.com -all")) == 1
-    
-    
+    assert (
+        len(validator.validate_spf_string("v=spf1 random include:example.com -all"))
+        == 1
+    )
+
+
 def test_too_many_includes():
-    includes = [f'include:{letter}.example.com' for letter in 'abcdefghijklmn']
+    includes = [f"include:{letter}.example.com" for letter in "abcdefghijklmn"]
     assert len(validator.validate_spf_string(f"v=spf1 {' '.join(includes)} -all")) == 1
-    
-    
+
+
 def test_catchall_false_positive():
-    assert len(validator.validate_spf_string("v=spf1 include:all.example.com -all")) == 0
+    assert (
+        len(validator.validate_spf_string("v=spf1 include:all.example.com -all")) == 0
+    )
 
 
 def test_normalize_domain_empty():
@@ -98,4 +103,3 @@ def test_normalize_domain_protocol():
 def test_normalize_domain_strips_www_only():
     assert validator._normalize_domain("www.example.com") == "example.com"
     assert validator._normalize_domain("example.com") == "example.com"
-

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -85,3 +85,17 @@ def test_too_many_includes():
     
 def test_catchall_false_positive():
     assert len(validator.validate_spf_string("v=spf1 include:all.example.com -all")) == 0
+
+
+def test_normalize_domain_empty():
+    assert validator._normalize_domain("") == ""
+
+
+def test_normalize_domain_protocol():
+    assert validator._normalize_domain("https://example.com") == "example.com"
+
+
+def test_normalize_domain_strips_www_only():
+    assert validator._normalize_domain("www.example.com") == "example.com"
+    assert validator._normalize_domain("example.com") == "example.com"
+


### PR DESCRIPTION
* Make small refactor to be able to test domain normalization part of getting domain SPF records
* Update project to test for Python 3.14
* Update project to test for dnspython 2.8
* Drop support for Python 3.9